### PR TITLE
Do not send credentials when they are None

### DIFF
--- a/couchdbkit/ext/django/loading.py
+++ b/couchdbkit/ext/django/loading.py
@@ -58,10 +58,10 @@ class CouchdbkitHandler(object):
         for app_name, app_setting in databases.iteritems():
             uri = app_setting['URL']
 
-            # Blank credentials are valid for the admin party
-            user = app_setting.get('USER', '')
-            password = app_setting.get('PASSWORD', '')
-            auth = BasicAuth(user, password)
+            # Do not send credentials when they are both None as admin party will give a 401
+            user = app_setting.get('USER')
+            password = app_setting.get('PASSWORD')
+            filters = [BasicAuth(user, password)] if (user or password) is not None else []
 
             try:
                 if isinstance(uri, (list, tuple)):
@@ -75,7 +75,7 @@ class CouchdbkitHandler(object):
                 raise ValueError("couchdb uri [%s:%s] invalid" % (
                     app_name, uri))
 
-            res = CouchdbResource(server_uri, timeout=COUCHDB_TIMEOUT, filters=[auth])
+            res = CouchdbResource(server_uri, timeout=COUCHDB_TIMEOUT, filters=filters)
 
             server = Server(server_uri, resource_instance=res)
             app_label = app_name.split('.')[-1]


### PR DESCRIPTION
This does not seem to occur for everyone, but I do not understand why not. Perhaps not much admin party use is around, but I do use it for some testing.

The issue seems obvious, inescapable, and immediately reproducible.

See https://github.com/apache/couchdb/blob/master/src/couchdb/couch_httpd_auth.erl#L55
https://github.com/apache/couchdb/blob/master/src/couchdb/couch_httpd_auth.erl#L66
