### PR TITLE
Add support for abstract meta property for mixins

### DIFF
--- a/couchdbkit/ext/django/schema.py
+++ b/couchdbkit/ext/django/schema.py
@@ -124,6 +124,9 @@ class DocumentMeta(schema.SchemaProperties):
         else:
             meta = attr_meta
 
+        if getattr(meta, 'abstract', False):
+            return new_class
+
         if getattr(meta, 'app_label', None) is None:
             document_module = sys.modules[new_class.__module__]
             app_label = document_module.__name__.split('.')[-2]


### PR DESCRIPTION
@czue @dannyroberts 

Usage:
```python
class FooMixin(Document):

    Meta:
        abstract = True

    foo = StringProperty()


class Concrete(Mixin, Document):

    bar = StringProperty()
```

Was not able to easily add a test for this, although I verified that it works in my local environment.