### PR TITLE
Add Document.bulk_delete, analagous to bulk_save

### DIFF
--- a/couchdbkit/schema/base.py
+++ b/couchdbkit/schema/base.py
@@ -152,12 +152,30 @@ class DocumentBase(DocumentSchema):
 
         """
         db = cls.get_db()
-        docs_to_save= [doc for doc in docs if doc._doc_type == cls._doc_type]
-        if not len(docs_to_save) == len(docs):
+        if any(doc._doc_type != cls._doc_type for doc in docs):
             raise ValueError("one of your documents does not have the correct type")
-        db.bulk_save(docs_to_save, use_uuids=use_uuids, all_or_nothing=all_or_nothing)
+        db.bulk_save(docs, use_uuids=use_uuids, all_or_nothing=all_or_nothing)
 
     bulk_save = save_docs
+
+    @classmethod
+    def delete_docs(cls, docs, all_or_nothing=False, empty_on_delete=False):
+        """ Bulk delete documents in a database
+
+        @params docs: list of couchdbkit.schema.Document instance
+        @param all_or_nothing: In the case of a power failure, when the database
+        restarts either all the changes will have been saved or none of them.
+        However, it does not do conflict checking, so the documents will
+        be committed even if this creates conflicts.
+        @param empty_on_delete: default is False if you want to make
+        """
+        db = cls.get_db()
+        if any(doc._doc_type != cls._doc_type for doc in docs):
+            raise ValueError("one of your documents does not have the correct type")
+        db.bulk_delete(docs, all_or_nothing=all_or_nothing,
+                       empty_on_delete=empty_on_delete)
+
+    bulk_delete = delete_docs
 
     @classmethod
     def get(cls, docid, rev=None, db=None, dynamic_properties=True):

--- a/couchdbkit/schema/base.py
+++ b/couchdbkit/schema/base.py
@@ -168,6 +168,8 @@ class DocumentBase(DocumentSchema):
         However, it does not do conflict checking, so the documents will
         be committed even if this creates conflicts.
         @param empty_on_delete: default is False if you want to make
+        sure the doc is emptied and will not be stored as is in Apache
+        CouchDB.
         """
         db = cls.get_db()
         if any(doc._doc_type != cls._doc_type for doc in docs):

--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -3,5 +3,5 @@
 # This file is part of couchdbkit released under the MIT license.
 # See the NOTICE for more information.
 
-version_info = (0, 7, 1, 0)
+version_info = (0, 7, 2, 0)
 __version__ =  ".".join(map(str, version_info))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -213,8 +213,6 @@ class DocumentTestCase(unittest.TestCase):
 
         self.server.delete_db('couchdbkit_test')
 
-
-
     def testGet(self):
         db = self.server.create_db('couchdbkit_test')
         class Test(Document):
@@ -634,6 +632,27 @@ class DocumentTestCase(unittest.TestCase):
         print list(db.all_docs(include_docs=True))
         self.assert_(len(db) == 0)
         self.assert_(db.info()['doc_del_count'] == 3)
+
+        self.server.delete_db('couchdbkit_test')
+
+    def testDocumentBulkDelete(self):
+        db = self.server.create_db('couchdbkit_test')
+
+        class Test(Document):
+            string = StringProperty()
+        Test._db = db
+
+        doc = Test()
+        doc.string = "test"
+        doc.save()
+        doc2 = Test()
+        doc2.string = "test2"
+        doc2.save()
+
+        Test.bulk_delete([doc, doc2])
+
+        with self.assertRaises(ResourceNotFound):
+            Test.get(doc._id)
 
         self.server.delete_db('couchdbkit_test')
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -651,8 +651,9 @@ class DocumentTestCase(unittest.TestCase):
 
         Test.bulk_delete([doc, doc2])
 
-        with self.assertRaises(ResourceNotFound):
-            Test.get(doc._id)
+        for doc_id in [doc._id, doc2._id]:
+            with self.assertRaises(ResourceNotFound):
+                Test.get(doc_id)
 
         self.server.delete_db('couchdbkit_test')
 


### PR DESCRIPTION
@dannyroberts @gcapalbo 
I wanted to add this in so we can override this method and hook into cache invalidation on `bulk_delete`.  `Document.bulk_save` already exists, and this is a straightforward parallel to that.