### PR TITLE
remove couchdbkit post_syncdb signal handler

### DIFF
--- a/couchdbkit/ext/django/__init__.py
+++ b/couchdbkit/ext/django/__init__.py
@@ -88,12 +88,3 @@ exemple :
 To create databases and sync views, just run the usual `syncdb` command.
 It won't destroy your datas, just synchronize views.
 """
-
-from django.db.models import signals
-
-def syncdb(app, created_models, verbosity=2, **kwargs):
-    """ function used by syncdb signal """
-    from couchdbkit.ext.django.loading import couchdbkit_handler
-    couchdbkit_handler.sync(app, verbosity=verbosity)
-
-signals.post_syncdb.connect(syncdb)


### PR DESCRIPTION
We don't need this anymore and the `post_syncdb` handler is removed in 1.9.

@czue 