### PR TITLE
making sure doc list for bulk save is accessable by index

### DIFF
--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -558,7 +558,7 @@ class Database(object):
 
         """
 
-        if not isinstance(docs, ('list', 'tuple')):
+        if not isinstance(docs, (list, tuple)):
             docs = tuple(docs)
         docs1 = []
         docs_schema = []

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -558,6 +558,8 @@ class Database(object):
 
         """
 
+        if not isinstance(docs, ('list', 'tuple')):
+            docs = tuple(docs)
         docs1 = []
         docs_schema = []
         for doc in docs:

--- a/couchdbkit/schema/base.py
+++ b/couchdbkit/schema/base.py
@@ -154,7 +154,7 @@ class DocumentBase(DocumentSchema):
         db = cls.get_db()
         if any(doc._doc_type != cls._doc_type for doc in docs):
             raise ValueError("one of your documents does not have the correct type")
-        db.bulk_save(docs, use_uuids=use_uuids, all_or_nothing=all_or_nothing)
+        db.bulk_save(tuple(docs), use_uuids=use_uuids, all_or_nothing=all_or_nothing)
 
     bulk_save = save_docs
 

--- a/couchdbkit/schema/base.py
+++ b/couchdbkit/schema/base.py
@@ -154,7 +154,7 @@ class DocumentBase(DocumentSchema):
         db = cls.get_db()
         if any(doc._doc_type != cls._doc_type for doc in docs):
             raise ValueError("one of your documents does not have the correct type")
-        db.bulk_save(tuple(docs), use_uuids=use_uuids, all_or_nothing=all_or_nothing)
+        db.bulk_save(docs, use_uuids=use_uuids, all_or_nothing=all_or_nothing)
 
     bulk_save = save_docs
 

--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -3,5 +3,5 @@
 # This file is part of couchdbkit released under the MIT license.
 # See the NOTICE for more information.
 
-version_info = (0, 7, 2, 0)
+version_info = (0, 7, 3, 0)
 __version__ =  ".".join(map(str, version_info))


### PR DESCRIPTION
@esoergel @dannyroberts cc: @czue @millerdev @emord 
Bulk upload of mobile workers was failing hard because the docs argument passed in was a set, and `bulk_save` tried to access elements by index. This makes sure the docs arg passed to bulk_save is always able to be accessed by index.