### PR TITLE
Fix Meta.abstract

### DIFF
--- a/couchdbkit/ext/django/schema.py
+++ b/couchdbkit/ext/django/schema.py
@@ -48,6 +48,7 @@ __all__ = ['Property', 'StringProperty', 'IntegerProperty',
 DEFAULT_NAMES = ('verbose_name', 'db_table', 'ordering',
                  'app_label', 'string_conversions', 'properties',
                  'update_properties')
+DISCARD_NAMES = ('abstract',)
 
 class Options(object):
     """ class based on django.db.models.options. We only keep
@@ -75,7 +76,7 @@ class Options(object):
                 # Ignore any private attributes that Django doesn't care about.
                 # NOTE: We can't modify a dictionary's contents while looping
                 # over it, so we loop over the *original* dictionary instead.
-                if name.startswith('_'):
+                if name.startswith('_') or name in DISCARD_NAMES:
                     del meta_attrs[name]
             for attr_name in DEFAULT_NAMES:
                 if attr_name in meta_attrs:
@@ -122,10 +123,9 @@ class DocumentMeta(schema.SchemaProperties):
         if not attr_meta:
             meta = getattr(new_class, 'Meta', None)
         else:
+            if getattr(attr_meta, 'abstract', False):
+                return new_class
             meta = attr_meta
-
-        if getattr(meta, 'abstract', False):
-            return new_class
 
         if getattr(meta, 'app_label', None) is None:
             document_module = sys.modules[new_class.__module__]

--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -3,5 +3,5 @@
 # This file is part of couchdbkit released under the MIT license.
 # See the NOTICE for more information.
 
-version_info = (0, 7, 3, 0)
+version_info = (0, 7, 4, 0)
 __version__ =  ".".join(map(str, version_info))


### PR DESCRIPTION
Do not propagate `Meta.abstract = True` to subclasses. This bug prevented `cls._meta.app_label` from being set on classes having a `Meta.abstract` base class as the nearest class in the inheritance chain with a `Meta` attribute.

Aside: it appears that `DocumentMeta` and `Options` only inspect the first `Meta` class in the inheritance chain for meta attributes. I can't tell for sure, but this may not be desirable or correct for some attributes. Example:

```python
class A(Document):
    class Meta:
        ordering = ['-a_field']

class B(A):
    class Meta:
        # this Meta class masks A.Meta attributes
        abstract = True

class C(B):
    """A.Meta.ordering does not apply here"""
```
@dannyroberts @czue 