### PR TITLE
test against couch 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ couchdbkit.egg-info
 dist/
 doc/_build/
 distribute-*
+data
+jsonobject_couchdbkit.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
 language: python
 
 services:
-    - couchdb
+  - docker
 
 python: 2.7
 
-install: 
-    - pip install -r requirements_dev.txt
-    - python setup.py install
+install:
+  - pip install -r requirements_dev.txt
+  - python setup.py install
+
+before_script:
+  - "docker run -d --name couchdb-cluster \
+    -p 5984:5984 \
+    -v $(pwd)/data:/usr/src/couchdb/dev/lib/ \
+    klaemo/couchdb:2.0-dev \
+    --with-admin-party-please \
+    --with-haproxy
+    -n 3"
+  - |
+    while :
+    do
+      curl http://localhost:5984/${db_name} -sv 2>&1 | grep '^< HTTP/.* 200 OK' && break || continue
+      sleep 1
+    done
+
 
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
     klaemo/couchdb:2.0-dev \
     --with-admin-party-please \
     --with-haproxy
-    -n 3"
+    -n 1"
   - |
     while :
     do

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -720,10 +720,6 @@ class Database(object):
         else:
             return self.res.get(view_path, **params)
 
-    def raw_temp_view(db, design, params):
-        return db.res.post('_temp_view', payload=design,
-               headers={"Content-Type": "application/json"}, **params)
-
     def view(self, view_name, schema=None, wrapper=None, **params):
         """ get view results from database. viewname is generally
         a string like `designname/viewname". It return an ViewResults
@@ -755,10 +751,6 @@ class Database(object):
             view_path = '_design/%s/_view/%s' % (dname, vname)
 
         return ViewResults(self.raw_view, view_path, wrapper, schema, params)
-
-    def temp_view(self, design, schema=None, wrapper=None, **params):
-        """ get adhoc view results. Like view it reeturn a ViewResult object."""
-        return ViewResults(self.raw_temp_view, design, wrapper, schema, params)
 
     def search( self, view_name, handler='_fti/_design', wrapper=None, schema=None, **params):
         """ Search. Return results from search. Use couchdb-lucene

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -541,15 +541,11 @@ class Database(object):
             doc.update(doc1)
         return res
 
-    def save_docs(self, docs, use_uuids=True, all_or_nothing=False, new_edits=None,
-            **params):
+    def save_docs(self, docs, use_uuids=True, new_edits=None, **params):
         """ bulk save. Modify Multiple Documents With a Single Request
 
         @param docs: list of docs
         @param use_uuids: add _id in doc who don't have it already set.
-        @param all_or_nothing: In the case of a power failure, when the database
-        restarts either all the changes will have been saved or none of them.
-        However, it does not do conflict checking, so the documents will
         @param new_edits: When False, this saves existing revisions instead of
         creating new ones. Used in the replication Algorithm. Each document
         should have a _revisions property that lists its revision history.
@@ -583,8 +579,6 @@ class Database(object):
                     doc['_id'] = nextid
 
         payload = { "docs": docs1 }
-        if all_or_nothing:
-            payload["all_or_nothing"] = True
         if new_edits is not None:
             payload["new_edits"] = new_edits
 
@@ -618,17 +612,13 @@ class Database(object):
         return results
     bulk_save = save_docs
 
-    def delete_docs(self, docs, all_or_nothing=False,
-            empty_on_delete=False, **params):
+    def delete_docs(self, docs, empty_on_delete=False, **params):
         """ bulk delete.
         It adds '_deleted' member to doc then uses bulk_save to save them.
 
         @param empty_on_delete: default is False if you want to make
         sure the doc is emptied and will not be stored as is in Apache
         CouchDB.
-        @param all_or_nothing: In the case of a power failure, when the database
-        restarts either all the changes will have been saved or none of them.
-        However, it does not do conflict checking, so the documents will
 
         .. seealso:: `HTTP Bulk Document API <http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API>`
 
@@ -646,8 +636,7 @@ class Database(object):
             for doc in docs:
                 doc['_deleted'] = True
 
-        return self.bulk_save(docs, use_uuids=False,
-                all_or_nothing=all_or_nothing, **params)
+        return self.bulk_save(docs, use_uuids=False, **params)
 
     bulk_delete = delete_docs
 

--- a/couchdbkit/schema/base.py
+++ b/couchdbkit/schema/base.py
@@ -140,33 +140,24 @@ class DocumentBase(DocumentSchema):
     store = save
 
     @classmethod
-    def save_docs(cls, docs, use_uuids=True, all_or_nothing=False):
+    def save_docs(cls, docs, use_uuids=True):
         """ Save multiple documents in database.
 
         @params docs: list of couchdbkit.schema.Document instance
         @param use_uuids: add _id in doc who don't have it already set.
-        @param all_or_nothing: In the case of a power failure, when the database
-        restarts either all the changes will have been saved or none of them.
-        However, it does not do conflict checking, so the documents will
-        be committed even if this creates conflicts.
-
         """
         db = cls.get_db()
         if any(doc._doc_type != cls._doc_type for doc in docs):
             raise ValueError("one of your documents does not have the correct type")
-        db.bulk_save(docs, use_uuids=use_uuids, all_or_nothing=all_or_nothing)
+        db.bulk_save(docs, use_uuids=use_uuids)
 
     bulk_save = save_docs
 
     @classmethod
-    def delete_docs(cls, docs, all_or_nothing=False, empty_on_delete=False):
+    def delete_docs(cls, docs, empty_on_delete=False):
         """ Bulk delete documents in a database
 
         @params docs: list of couchdbkit.schema.Document instance
-        @param all_or_nothing: In the case of a power failure, when the database
-        restarts either all the changes will have been saved or none of them.
-        However, it does not do conflict checking, so the documents will
-        be committed even if this creates conflicts.
         @param empty_on_delete: default is False if you want to make
         sure the doc is emptied and will not be stored as is in Apache
         CouchDB.
@@ -174,8 +165,7 @@ class DocumentBase(DocumentSchema):
         db = cls.get_db()
         if any(doc._doc_type != cls._doc_type for doc in docs):
             raise ValueError("one of your documents does not have the correct type")
-        db.bulk_delete(docs, all_or_nothing=all_or_nothing,
-                       empty_on_delete=empty_on_delete)
+        db.bulk_delete(docs, empty_on_delete=empty_on_delete)
 
     bulk_delete = delete_docs
 

--- a/couchdbkit/schema/base.py
+++ b/couchdbkit/schema/base.py
@@ -301,35 +301,15 @@ class QueryMixin(object):
             dynamic_properties=dynamic_properties, wrap_doc=wrap_doc,
             wrapper=wrapper, schema=classes, **params)
 
-    @classmethod
-    def temp_view(cls, design, wrapper=None, dynamic_properties=None,
-    wrap_doc=True, classes=None, **params):
-        """ Slow view. Like in view method,
-        results are automatically wrapped to
-        Document object.
-
-        @params design: design object, See `simplecouchd.client.Database`
-        @dynamic_properties: do we handle properties which aren't in
-            the schema ?
-        @wrap_doc: If True, if a doc is present in the row it will be
-            used for wrapping. Default is True.
-        @params params:  params of view
-
-        @return: Like view, return a :class:`simplecouchdb.core.ViewResults`
-        instance. All results are wrapped to current document instance.
-        """
-        db = cls.get_db()
-        return db.temp_view(design,
-            dynamic_properties=dynamic_properties, wrap_doc=wrap_doc,
-            wrapper=wrapper, schema=classes or cls, **params)
 
 class Document(DocumentBase, QueryMixin, AttachmentMixin):
     """
     Full featured document object implementing the following :
 
-    :class:`QueryMixin` for view & temp_view that wrap results to this object
+    :class:`QueryMixin` for view that wrap results to this object
     :class `AttachmentMixin` for attachments function
     """
+
 
 class StaticDocument(Document):
     """

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -637,26 +637,6 @@ class ClientViewTestCase(unittest.TestCase):
         self.assert_(count == 2)
         del self.Server['couchdbkit_test']
 
-    def testTemporaryView(self):
-        db = self.Server.create_db('couchdbkit_test')
-        # save 2 docs
-        doc1 = { '_id': 'test', 'string': 'test', 'number': 4,
-                'docType': 'test' }
-        db.save_doc(doc1)
-        doc2 = { '_id': 'test2', 'string': 'test', 'number': 2,
-                    'docType': 'test'}
-        db.save_doc(doc2)
-
-        design_doc = {
-            "map": """function(doc) { if (doc.docType == "test") { emit(doc._id, doc);
-}}"""
-        }
-
-        results = db.temp_view(design_doc)
-        self.assert_(len(results) == 2)
-        del self.Server['couchdbkit_test']
-
-
     def testView2(self):
         db = self.Server.create_db('couchdbkit_test')
         # save 2 docs

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -497,61 +497,6 @@ class ClientDatabaseTestCase(unittest.TestCase):
 
         del self.Server['couchdbkit_test']
 
-    def testMultipleDocCOnflict(self):
-        db = self.Server.create_db('couchdbkit_test')
-        docs = [
-                { 'string': 'test', 'number': 4 },
-                { 'string': 'test', 'number': 5 },
-                { 'string': 'test', 'number': 4 },
-                { 'string': 'test', 'number': 6 }
-        ]
-        db.bulk_save(docs)
-        self.assert_(len(db) == 4)
-        docs1 = [
-                docs[0],
-                docs[1],
-                {'_id': docs[2]['_id'], 'string': 'test', 'number': 4 },
-                {'_id': docs[3]['_id'], 'string': 'test', 'number': 6 }
-        ]
-
-        self.assertRaises(BulkSaveError, db.bulk_save, docs1)
-
-        docs2 = [
-            docs1[0],
-            docs1[1],
-            {'_id': docs[2]['_id'], 'string': 'test', 'number': 4 },
-            {'_id': docs[3]['_id'], 'string': 'test', 'number': 6 }
-        ]
-        doc23 = docs2[3].copy()
-        all_errors = []
-        try:
-            db.bulk_save(docs2)
-        except BulkSaveError, e:
-            all_errors = e.errors
-
-        self.assert_(len(all_errors) == 2)
-        self.assert_(all_errors[0]['error'] == 'conflict')
-        self.assert_(doc23 == docs2[3])
-
-        docs3 = [
-            docs2[0],
-            docs2[1],
-            {'_id': docs[2]['_id'], 'string': 'test', 'number': 4 },
-            {'_id': docs[3]['_id'], 'string': 'test', 'number': 6 }
-        ]
-
-        doc33 = docs3[3].copy()
-        all_errors2 = []
-        try:
-            db.bulk_save(docs3, all_or_nothing=True)
-        except BulkSaveError, e:
-            all_errors2 = e.errors
-
-        self.assert_(len(all_errors2) == 0)
-        self.assert_(doc33 != docs3[3])
-        del self.Server['couchdbkit_test']
-
-
     def testCopy(self):
         db = self.Server.create_db('couchdbkit_test')
         doc = { "f": "a" }

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -31,19 +31,18 @@ class ClientServerTestCase(unittest.TestCase):
         except:
             pass
 
-
     def test_fetch(self):
         res1 = self.consumer.fetch()
-        self.assert_("last_seq" in res1)
-        self.assert_(res1["last_seq"] == 0)
-        self.assert_(res1["results"] == [])
+        self.assertTrue("last_seq" in res1)
+        self.assertTrue(res1["last_seq"].startswith("0"))
+        self.assertEqual(res1["results"], [])
         doc = {}
         self.db.save_doc(doc)
         res2 = self.consumer.fetch()
-        self.assert_(res2["last_seq"] == 1)
-        self.assert_(len(res2["results"]) == 1)
+        self.assertTrue(res2["last_seq"].startswith("1"))
+        self.assertEqual(len(res2["results"]), 1)
         line = res2["results"][0]
-        self.assert_(line["id"] == doc["_id"])
+        self.assertEqual(line["id"], doc["_id"])
 
     def test_longpoll(self):
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -530,31 +530,6 @@ class DocumentTestCase(unittest.TestCase):
         self.assert_(len(results) == 2)
         self.server.delete_db('couchdbkit_test')
 
-
-    def testTempView(self):
-        class TestDoc(Document):
-            field1 = StringProperty()
-            field2 = StringProperty()
-
-        design_doc = {
-            "map": """function(doc) { if (doc.doc_type == "TestDoc") { emit(doc._id, doc);
-}}"""
-        }
-
-        doc = TestDoc(field1="a", field2="b")
-        doc1 = TestDoc(field1="c", field2="d")
-
-        db = self.server.create_db('couchdbkit_test')
-        TestDoc._db = db
-
-        doc.save()
-        doc1.save()
-        results = TestDoc.temp_view(design_doc)
-        self.assert_(len(results) == 2)
-        doc3 = list(results)[0]
-        self.assert_(hasattr(doc3, "field1"))
-        self.server.delete_db('couchdbkit_test')
-
     def testDocumentAttachments(self):
         db = self.server.create_db('couchdbkit_test')
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -15,6 +15,7 @@ except ImportError:
 from couchdbkit import *
 from couchdbkit.schema.properties import support_setproperty
 
+
 class DocumentTestCase(unittest.TestCase):
     def setUp(self):
         self.server = Server()
@@ -715,8 +716,6 @@ class PropertyTestCase(unittest.TestCase):
             value = test.field
             self.assert_(isinstance(value, datetime.datetime))
 
-
-
     def testDateProperty(self):
         class Test(Document):
             field = DateProperty()
@@ -730,7 +729,6 @@ class PropertyTestCase(unittest.TestCase):
         self.assert_(test._doc['field'] == "2008-11-10")
         value = test.field
         self.assert_(isinstance(value, datetime.date))
-
 
     def testTimeProperty(self):
         class Test(Document):
@@ -789,7 +787,6 @@ class PropertyTestCase(unittest.TestCase):
         self.assert_(isinstance(v1, datetime.datetime))
         self.assert_(isinstance(vd, basestring))
 
-
     def testSchemaProperty1(self):
         class MySchema(DocumentSchema):
             astring = StringProperty()
@@ -812,7 +809,6 @@ class PropertyTestCase(unittest.TestCase):
         self.assert_(isinstance(doc2.schema, MySchema) == True)
         self.assert_(doc2.schema.astring == u"test")
         self.assert_(doc2._doc['schema']['astring'] == u"test")
-
 
     def testSchemaPropertyWithRequired(self):
         class B( Document ):
@@ -1042,7 +1038,6 @@ class PropertyTestCase(unittest.TestCase):
         self.assert_(len(b1.slm) == 2)
         self.assert_(b1.slm[0].s == "test")
 
-
     def testSchemaListPropertySlice(self):
         """SchemaListProperty slice methods
         """
@@ -1079,7 +1074,6 @@ class PropertyTestCase(unittest.TestCase):
             'slm': [{'doc_type': 'A', 's': unicode(a1.s)}]
         })
 
-
     def testSchemaListPropertyContains(self):
         """SchemaListProperty contains method
         """
@@ -1098,7 +1092,6 @@ class PropertyTestCase(unittest.TestCase):
         self.assertTrue(a1 in b.slm)
         self.assertFalse(a2 in b.slm)
 
-
     def testSchemaListPropertyCount(self):
         """SchemaListProperty count method
         """
@@ -1115,7 +1108,6 @@ class PropertyTestCase(unittest.TestCase):
         a2.s = 'test2'
         b.slm = [a1, a2, a1]
         self.assertEqual(b.slm.count(a1), 2)
-
 
     def testSchemaListPropertyExtend(self):
         """SchemaListProperty extend method
@@ -1196,7 +1188,6 @@ class PropertyTestCase(unittest.TestCase):
                     {'doc_type': 'A', 's': unicode(a3.s)}]
         })
 
-
     def testSchemaListPropertyPop(self):
         """SchemaListProperty pop method
         """
@@ -1231,7 +1222,6 @@ class PropertyTestCase(unittest.TestCase):
             'doc_type': 'B',
             'slm': [{'doc_type': 'A', 's': unicode(a2.s)}]
         })
-
 
     def testSchemaListPropertyRemove(self):
         """SchemaListProperty remove method
@@ -1285,7 +1275,6 @@ class PropertyTestCase(unittest.TestCase):
                     {'doc_type': 'A', 's': unicode(a1.s)}]
         })
 
-
     def testSchemaListPropertySort(self):
         """SchemaListProperty sort method
         """
@@ -1323,7 +1312,6 @@ class PropertyTestCase(unittest.TestCase):
                     {'doc_type': 'A', 's': unicode(a2.s)}]
         })
 
-
     def testSchemaDictProperty(self):
         class A(DocumentSchema):
             i = IntegerProperty()
@@ -1351,7 +1339,6 @@ class PropertyTestCase(unittest.TestCase):
         self.assert_(len(b1.d) == 2)
         self.assert_(b1.d['v1'].i == 123)
         self.assert_(b1.d[23].i == 42)
-
 
     def testListProperty(self):
         from datetime import datetime
@@ -1431,7 +1418,6 @@ class PropertyTestCase(unittest.TestCase):
         b1.ls.remove(u'hello')
         self.assert_(u'hello' not in b1.ls)
 
-
     def testListPropertyExtend(self):
         """list extend method for property w/o type
         """
@@ -1442,7 +1428,6 @@ class PropertyTestCase(unittest.TestCase):
         a.l.extend([42, 24])
         self.assert_(a.l == [42, 24])
         self.assert_(a._doc == {'doc_type': 'A', 'l': [42, 24]})
-
 
     def testListPropertyExtendWithType(self):
         """list extend method for property w/ type
@@ -1461,7 +1446,6 @@ class PropertyTestCase(unittest.TestCase):
             'l': ['2011-03-11T21:31:01Z', '2011-11-03T13:12:02Z']
         })
 
-
     def testListPropertyInsert(self):
         """list insert method for property w/o type
         """
@@ -1473,7 +1457,6 @@ class PropertyTestCase(unittest.TestCase):
         a.l.insert(1, 4224)
         self.assertEqual(a.l, [42, 4224, 24])
         self.assertEqual(a._doc, {'doc_type': 'A', 'l': [42, 4224, 24]})
-
 
     def testListPropertyInsertWithType(self):
         """list insert method for property w/ type
@@ -1496,7 +1479,6 @@ class PropertyTestCase(unittest.TestCase):
                   '2010-01-12T03:02:03Z']
         })
 
-
     def testListPropertyPop(self):
         """list pop method for property w/o type
         """
@@ -1514,7 +1496,6 @@ class PropertyTestCase(unittest.TestCase):
         self.assert_(a.l == [24])
         self.assert_(a._doc == {'doc_type': 'A', 'l': [24]})
 
-
     def testListPropertyPopWithType(self):
         """list pop method for property w/ type
         """
@@ -1530,7 +1511,6 @@ class PropertyTestCase(unittest.TestCase):
         v = a.l.pop()
         self.assertEqual(v, d3)
         self.assertEqual(a.l, [d1, d2])
-
 
     def testDictProperty(self):
         from datetime import datetime
@@ -1798,7 +1778,6 @@ class PropertyTestCase(unittest.TestCase):
         b.d = {}
         self.assert_(b.d == {})
         self.assert_(b.to_json()['d'] == {})
-
 
 
 if support_setproperty:


### PR DESCRIPTION
Realized we've never actually tested this on couch 2. Here's some fun failures:

`reason":"all_or_nothing is not supported"}`
`Unauthorized: {"error":"forbidden","reason":"Temporary views are not supported in CouchDB"}`
`PreconditionFailed: The database could not be created, the file already exists.`

@dannyroberts @snopoke 