### PR TITLE
Bump version to 0.9.0.0

### DIFF
--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -3,5 +3,5 @@
 # This file is part of couchdbkit released under the MIT license.
 # See the NOTICE for more information.
 
-version_info = (0, 8, 0, 2)
+version_info = (0, 9, 0, 0)
 __version__ =  ".".join(map(str, version_info))


### PR DESCRIPTION
Because we dropped support for couch 1.x in #26 