### PR TITLE
Je/cloudant lib pt1

### DIFF
--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -36,6 +36,7 @@ from itertools import groupby
 from mimetypes import guess_type
 import time
 
+from cloudant.client import CouchDB
 from restkit.util import url_quote
 
 from .exceptions import InvalidAttachment, NoResultFound, \
@@ -104,6 +105,8 @@ class Server(object):
         else:
             self.res = self.resource_class(uri, **client_opts)
         self._uuids = deque()
+        # admin_party is true, because the username/pass is passed in uri for now
+        self.cloudant_client = CouchDB('', '', url=uri, admin_party=True, connect=True)
 
     def info(self):
         """ info of server

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -26,11 +26,6 @@ Example:
     >>> del server['simplecouchdb_test']
 
 """
-from couchdbkit.logging import error_logger
-
-UNKOWN_INFO = {}
-
-
 from collections import deque
 from copy import deepcopy
 from itertools import groupby
@@ -46,10 +41,11 @@ from cloudant.security_document import SecurityDocument
 from requests.exceptions import HTTPError
 from restkit.util import url_quote
 import six
-from six.moves.urllib.parse import quote, urljoin, unquote
+from six.moves.urllib.parse import urljoin, unquote
 
+from couchdbkit.logging import error_logger
 from .exceptions import InvalidAttachment, NoResultFound, \
-ResourceNotFound, ResourceConflict, BulkSaveError, MultipleResultsFound
+        ResourceNotFound, ResourceConflict, BulkSaveError, MultipleResultsFound
 from . import resource
 from .utils import validate_dbname
 
@@ -57,6 +53,7 @@ from .schema.util import maybe_schema_wrapper
 
 
 DEFAULT_UUID_BATCH_COUNT = 1000
+UNKOWN_INFO = {}
 
 
 def _maybe_serialize(doc):

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -39,6 +39,7 @@ import time
 from cloudant.client import CouchDB
 from cloudant.database import CouchDatabase
 from cloudant.document import Document
+from cloudant.security_document import SecurityDocument
 from restkit.util import url_quote
 from six.moves.urllib.parse import urljoin, unquote
 
@@ -279,9 +280,13 @@ class Database(object):
 
         self.res = server.res(self.dbname)
         self._request_session = self.server._request_session
+        self.database_url = self.cloudant_database.database_url
 
     def __repr__(self):
         return "<%s %s>" % (self.__class__.__name__, self.dbname)
+
+    def _database_path(self, path):
+        return '/'.join([self.database_url, path])
 
     def info(self):
         """
@@ -293,11 +298,17 @@ class Database(object):
 
     def set_security(self, secobj):
         """ set database securrity object """
-        return self._request_session.put(urljoin(self.uri, "/_security"), data=secobj).json()
+        with SecurityDocument(self.cloudant_database) as sec_doc:
+            # context manager saves
+            for key in sec_doc:
+                del sec_doc[key]
+            for k, v in secobj.items():
+                sec_doc[k] = v
+        return self.get_security()
 
     def get_security(self):
         """ get database secuirity object """
-        return self._request_session.get(urljoin(self.uri, "/_security"), data=secobj).json()
+        return self.cloudant_database.get_security_document()
 
     def compact(self, dname=None):
         """ compact database
@@ -307,9 +318,8 @@ class Database(object):
         path = "/_compact"
         if dname is not None:
             path = "%s/%s" % (path, resource.escape_docid(dname))
-        path = urljoin(self.uri, path)
-        res = self._request_session.post(path, headers={"Content-Type":
-            "application/json"})
+        path = self._database_path(path)
+        res = self._request_session.post(path, headers={"Content-Type": "application/json"})
         return res.json()
 
     def view_cleanup(self):
@@ -320,9 +330,7 @@ class Database(object):
         except design docs."""
 
         # save ddocs
-        all_ddocs = self.all_docs(startkey="_design",
-                            endkey="_design/"+u"\u9999",
-                            include_docs=True)
+        all_ddocs = self.all_docs(startkey="_design", endkey="_design/"+u"\u9999", include_docs=True)
         ddocs = []
         for ddoc in all_ddocs:
             doc = ddoc['doc']

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -502,8 +502,8 @@ class Database(object):
 
         @return rev: str, the last revision of document.
         """
-        response = self.res.head(resource.escape_docid(docid))
-        return response['etag'].strip('"')
+        response = self._request_session.head(self._database_path(docid))
+        return response.headers['ETag'].strip('"')
 
     def save_doc(self, doc, encode_attachments=True, force_update=False,
             **params):

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -196,10 +196,12 @@ class Server(object):
     def active_tasks(self):
         """ return active tasks """
         resp = self._request_session.get(urljoin(self.uri, '/_active_tasks'))
+        resp.raise_for_status()
         return resp.json()
 
     def uuids(self, count=1):
         resp = self._request_session.get(urljoin(self.uri, '/_uuids'), params={'count': count})
+        resp.raise_for_status()
         return resp.json()
 
     def next_uuid(self, count=None):
@@ -323,6 +325,7 @@ class Database(object):
             path = "%s/%s" % (path, resource.escape_docid(dname))
         path = self._database_path(path)
         res = self._request_session.post(path, headers={"Content-Type": "application/json"})
+        res.raise_for_status()
         return res.json()
 
     def view_cleanup(self):
@@ -503,6 +506,7 @@ class Database(object):
         @return rev: str, the last revision of document.
         """
         response = self._request_session.head(self._database_path(docid))
+        response.raise_for_status()
         return response.headers['ETag'].strip('"')
 
     def save_doc(self, doc, encode_attachments=True, force_update=False,
@@ -603,9 +607,11 @@ class Database(object):
             payload["new_edits"] = new_edits
 
         # update docs
-        results = self._request_session.post(
+        res = self._request_session.post(
             self._database_path('_bulk_docs'), data=json.dumps(payload),
-            headers={"Content-Type": "application/json"}, **params).json()
+            headers={"Content-Type": "application/json"}, **params)
+        res.raise_for_status()
+        results = res.json()
 
         errors = []
         for i, res in enumerate(results):
@@ -685,10 +691,12 @@ class Database(object):
             couch_doc['_rev'] = self.get_rev(doc1)
 
         # manual request because cloudant library doesn't return result
-        result = self._request_session.delete(
+        res = self._request_session.delete(
             couch_doc.document_url,
             params={"rev": couch_doc["_rev"]},
-        ).json()
+        )
+        res.raise_for_status()
+        result = res.json()
 
         if schema:
             doc._doc.update({
@@ -910,6 +918,7 @@ class Database(object):
         """ commit all docs in memory """
         path = self._database_path('_ensure_full_commit')
         res = self._request_session.post(path, headers={"Content-Type": "application/json"})
+        res.raise_for_status()
         return res.json()
 
     def __len__(self):

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -875,9 +875,7 @@ class Database(object):
             doc.update(new_doc)
         return res['ok']
 
-
-    def fetch_attachment(self, id_or_doc, name, stream=False,
-            headers=None):
+    def fetch_attachment(self, id_or_doc, name, stream=False, headers=None):
         """ get attachment in a document
 
         @param id_or_doc: str or dict, doc id or document dict
@@ -903,9 +901,9 @@ class Database(object):
 
     def ensure_full_commit(self):
         """ commit all docs in memory """
-        return self.res.post('_ensure_full_commit', headers={
-            "Content-Type": "application/json"
-        }).json_body
+        path = self._database_path('_ensure_full_commit')
+        res = self._request_session.post(path, headers={"Content-Type": "application/json"})
+        return res.json()
 
     def __len__(self):
         return self.info()['doc_count']
@@ -920,15 +918,15 @@ class Database(object):
         doc['_id'] = docid
         self.save_doc(doc)
 
-
     def __delitem__(self, docid):
-       self.delete_doc(docid)
+        self.delete_doc(docid)
 
     def __iter__(self):
         return self.documents().iterator()
 
     def __nonzero__(self):
         return (len(self) > 0)
+
 
 class ViewResults(object):
     """

--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -723,7 +723,7 @@ class Database(object):
         if isinstance(doc1, basestring):
             docid = doc1
         else:
-            if not '_id' in doc1:
+            if '_id' not in doc1:
                 raise KeyError('_id is required to copy a doc')
             docid = doc1['_id']
 
@@ -743,10 +743,11 @@ class Database(object):
 
         if destination:
             headers.update({"Destination": str(destination)})
-            result = self.res.copy('/%s' % docid, headers=headers).json_body
-            return result
+            resp = self._request_session.request('copy', self._database_path(docid), headers=headers)
+            resp.raise_for_status()
+            return resp.json()
 
-        return { 'ok': False }
+        return {'ok': False}
 
     def raw_view(self, view_path, params):
         if 'keys' in params:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 restkit>=4.2.2
+jsonobject>=0.6.0
+cloudant==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 restkit>=4.2.2
 jsonobject>=0.6.0
 cloudant==2.7.0
+six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     install_requires = [
         'restkit>=4.2.2',
         'jsonobject>=0.6.0',
+        'cloudant==2.7.0',
     ],
     provides=['couchdbkit'],
     obsoletes=['couchdbkit'],

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'restkit>=4.2.2',
         'jsonobject>=0.6.0',
         'cloudant==2.7.0',
+        'six==1.11.0',
     ],
     provides=['couchdbkit'],
     obsoletes=['couchdbkit'],

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -566,8 +566,9 @@ class ClientDatabaseTestCase(unittest.TestCase):
 
     def testSetSecurity(self):
         db = self.Server.create_db('couchdbkit_test')
-        res = db.set_security({"meta": "test"})
-        self.assert_(res['ok'] == True)
+        sec_doc = {"meta": "test"}
+        res = db.set_security(sec_doc)
+        self.assertEquals(res, sec_doc)
         del self.Server['couchdbkit_test']
 
     def testGetSecurity(self):
@@ -824,4 +825,3 @@ class ClientViewTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
@dimagi/py3 This moves almost the entire client to using the cloudant lib. the only thing left is the attachment endpoints and three other endpoints (https://github.com/dimagi/couchdbkit/pull/24/commits/e3c55dc6a806c6ccb2eb31a72a8ae783e5b40ef8)

Should be reviewable commit by commit