### PR TITLE
open_doc should return a dict, not a cloudant Document

### DIFF
--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -415,6 +415,7 @@ class Database(object):
             if e.response.status_code == 404:
                 raise ResourceNotFound
             raise
+        doc = json.loads(doc.json())
         if wrapper is not None:
             if not callable(wrapper):
                 raise TypeError("wrapper isn't a callable")

--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -5,5 +5,5 @@
 
 from __future__ import absolute_import
 from six.moves import map
-version_info = (0, 9, 0, 1)
+version_info = (0, 9, 0, 3)
 __version__ =  ".".join(map(str, version_info))


### PR DESCRIPTION
This resolves the issue with pickling couch docs.

Skipping version 0.9.0.2 intentionally.