### PR TITLE
raise ResourceNotFound when trying to delete an already deleted doc

### DIFF
--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -726,10 +726,7 @@ class Database(object):
             couch_doc['_rev'] = doc1['_rev']
         elif isinstance(doc1, six.string_types): # we get a docid
             couch_doc = Document(self.cloudant_database, doc1)
-            try:
-                couch_doc['_rev'] = self.get_rev(doc1)
-            except ResourceNotFound:
-                raise ResourceConflict
+            couch_doc['_rev'] = self.get_rev(doc1)
 
         # manual request because cloudant library doesn't return result
         res = self._request_session.delete(

--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -5,5 +5,5 @@
 
 from __future__ import absolute_import
 from six.moves import map
-version_info = (0, 9, 0, 3, 7)
+version_info = (0, 9, 0, 3, 8)
 __version__ =  ".".join(map(str, version_info))


### PR DESCRIPTION
Issue was caught during HQ tests.  I thought I had demonstrated to myself that a ```ResourceConflict``` would maintain the existing interface, but actually a ```ResourceNotFound``` should be raised.

@emord 