### PR TITLE
add metadata to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ cover-package=couchdbkit
 
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
For consistency with https://confluence.dimagi.com/display/commcarehq/Python+Packaging+Crash+Course