### PR TITLE
unblock python3 tests

### DIFF
--- a/couchdbkit/client.py
+++ b/couchdbkit/client.py
@@ -390,8 +390,10 @@ class Database(object):
             wrapper = schema.wrap
         attachments = params.get('attachments', False)
 
-        if isinstance(docid, six.text_type):
+        if six.PY2 and isinstance(docid, six.text_type):
             docid = docid.encode('utf-8')
+        if six.PY3 and isinstance(docid, bytes):
+            docid = docid.decode('utf-8')
         doc = Document(self.cloudant_database, docid)
         try:
             doc.fetch()
@@ -494,7 +496,7 @@ class Database(object):
             doc1['_attachments'] = resource.encode_attachments(doc['_attachments'])
 
         if '_id' in doc1:
-            docid = doc1['_id'].encode('utf-8')
+            docid = doc1['_id'] if six.PY3 else doc1['_id'].encode('utf-8')
             couch_doc = Document(self.cloudant_database, docid)
             couch_doc.update(doc1)
             try:

--- a/couchdbkit/ext/django/schema.py
+++ b/couchdbkit/ext/django/schema.py
@@ -30,7 +30,7 @@ except ImportError:
 from django.conf import settings
 from django.utils.translation import activate, deactivate_all, get_language, \
 string_concat
-from django.utils.encoding import smart_str, force_unicode
+from django.utils.encoding import smart_str, force_text
 
 from couchdbkit import schema
 from couchdbkit.ext.django.loading import get_schema, register_schema, \
@@ -108,7 +108,7 @@ class Options(object):
         """
         lang = get_language()
         deactivate_all()
-        raw = force_unicode(self.verbose_name)
+        raw = force_text(self.verbose_name)
         activate(lang)
         return raw
     verbose_name_raw = property(verbose_name_raw)

--- a/couchdbkit/utils.py
+++ b/couchdbkit/utils.py
@@ -14,12 +14,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 import codecs
 import string
-import urllib
 from hashlib import md5
 import os
 import re
 import sys
-import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 import six
 from six.moves import range
 
@@ -243,4 +241,4 @@ def url_quote(s, safe='/:'):
         s = s.encode('utf-8')
     elif not isinstance(s, six.binary_type):
         s = six.binary_type(s)
-    return urllib.quote(s, safe=safe)
+    return six.moves.urllib.parse.quote(s, safe=safe)

--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -4,5 +4,5 @@
 # See the NOTICE for more information.
 
 from __future__ import absolute_import
-version_info = (0, 9, 8)
+version_info = (0, 9, 9)
 __version__ = ".".join([str(vi) for vi in version_info])


### PR DESCRIPTION
I'm not ready to call this py3 compatible, since the ```from __future__ import *``` imports haven't been added yet.  But this unblocks HQ's db tests.