### PR TITLE
Unpin requirements

### DIFF
--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -4,5 +4,5 @@
 # See the NOTICE for more information.
 
 from __future__ import absolute_import
-version_info = (0, 9, 13)
+version_info = (0, 9, 14)
 __version__ = ".".join([str(vi) for vi in version_info])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 jsonobject>=0.6.0
-cloudant==2.7.0
-six==1.11.0
+cloudant~=2.7
+six

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
 
     install_requires = [
         'jsonobject>=0.9.1',
-        'cloudant==2.7.0',
+        'cloudant~=2.7',
         'six==1.11.0',
     ],
     provides=['couchdbkit'],


### PR DESCRIPTION
This unpins cloudant and six from exact versions so that downstream dependencies (HQ) doesn't need to have an out of date version