### PR TITLE
Remove version dependency on six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires = [
         'jsonobject>=0.9.8',
         'cloudant~=2.7',
-        'six==1.11.0',
+        'six',
     ],
     provides=['couchdbkit'],
     obsoletes=['couchdbkit'],


### PR DESCRIPTION
So that it doesn't restrict downstream dependencies