### PR TITLE
Resolve `SyntaxError: invalid escape sequence`

### DIFF
--- a/couchdbkit/designer/fs.py
+++ b/couchdbkit/designer/fs.py
@@ -258,9 +258,10 @@ class FSDoc(object):
         return False
 
     def dir_to_fields(self, current_dir='', depth=0,
-                manifest=[]):
+                manifest=None):
         """ process a directory and get all members """
-
+        if manifest is None:
+            manifest = []
         fields={}
         if not current_dir:
             current_dir = self.docdir

--- a/couchdbkit/designer/fs.py
+++ b/couchdbkit/designer/fs.py
@@ -131,7 +131,7 @@ class FSDoc(object):
     def attachment_stub(self, name, filepath):
         att = {}
         with open(filepath, "rb") as f:
-            re_sp = re.compile('\s')
+            re_sp = re.compile(r'\s')
             att = {
                     "data": re_sp.sub('',base64.b64encode(f.read())),
                     "content_type": ';'.join(filter(None,

--- a/couchdbkit/designer/macros.py
+++ b/couchdbkit/designer/macros.py
@@ -91,7 +91,7 @@ def run_code_macros(f_string, app_dir):
            "Processing code: No file matching '%s'" % mo.group(2))
        return library
 
-   re_code = re.compile('(\/\/|#)\ ?!code (.*)')
+   re_code = re.compile(r'(//|#) ?!code (.*)')
    return re_code.sub(rreq, f_string)
 
 def run_json_macros(doc, f_string, app_dir):
@@ -150,7 +150,7 @@ def run_json_macros(doc, f_string, app_dir):
    def rjson2(mo):
        return '\n'.join(varstrings)
 
-   re_json = re.compile('(\/\/|#)\ ?!json (.*)')
+   re_json = re.compile(r'(//|#) ?!json (.*)')
    re_json.sub(rjson, f_string)
 
    if not included:

--- a/couchdbkit/ext/django/schema.py
+++ b/couchdbkit/ext/django/schema.py
@@ -65,7 +65,7 @@ class Options(object):
 
     def contribute_to_class(self, cls, name):
         cls._meta = self
-        self.installed = re.sub('\.models$', '', cls.__module__) in settings.INSTALLED_APPS
+        self.installed = re.sub(r'\.models$', '', cls.__module__) in settings.INSTALLED_APPS
         # First, construct the default values for these options.
         self.object_name = cls.__name__
         self.module_name = self.object_name.lower()

--- a/couchdbkit/resource.py
+++ b/couchdbkit/resource.py
@@ -53,7 +53,7 @@ def escape_docid(docid):
         docid = url_quote(docid, safe='')
     return docid
 
-re_sp = re.compile('\s')
+re_sp = re.compile(r'\s')
 def encode_attachments(attachments):
     for k, v in six.iteritems(attachments):
         if v.get('stub', False):


### PR DESCRIPTION
The [`DeprecationWarning` in Python 3.8](https://docs.python.org/3.8/library/re.html) has become a `SyntaxError` in Python 3.9 (unless I'm missing something?)

This change uses raw strings for escape sequences.

It also fixes a mutable default value I noticed.

Tested escape sequences locally on Python 3.9.