### PR TITLE
Replace force_text with force_str

### DIFF
--- a/couchdbkit/ext/django/schema.py
+++ b/couchdbkit/ext/django/schema.py
@@ -30,7 +30,7 @@ except ImportError:
 from django.conf import settings
 from django.utils.text import format_lazy
 from django.utils.translation import activate, deactivate_all, get_language
-from django.utils.encoding import smart_str, force_text
+from django.utils.encoding import smart_str, force_str
 
 from couchdbkit import schema
 from couchdbkit.ext.django.loading import get_schema, register_schema, \
@@ -109,7 +109,7 @@ class Options(object):
         """
         lang = get_language()
         deactivate_all()
-        raw = force_text(self.verbose_name)
+        raw = force_str(self.verbose_name)
         activate(lang)
         return raw
     verbose_name_raw = property(verbose_name_raw)


### PR DESCRIPTION
This is for Django 4.2 compatibility. From the Django 3 release docs:
> Features deprecated in 3.0¶
django.utils.encoding.force_text() and smart_text()¶
The smart_text() and force_text() aliases (since Django 2.0) of smart_str() and force_str() are deprecated. Ignore this deprecation if your code supports Python 2 as the behavior of smart_str() and force_str() is different there.

If we care about keeping compatibility with Python 2, I should add a check for which version of python is running for this import, but otherwise this should suffice.