### PR TITLE
Bump from 1.0.1 to 1.1.0

### DIFF
--- a/couchdbkit/version.py
+++ b/couchdbkit/version.py
@@ -4,5 +4,5 @@
 # See the NOTICE for more information.
 
 from __future__ import absolute_import
-version_info = (1, 0, 1)
+version_info = (1, 1, 0)
 __version__ = ".".join([str(vi) for vi in version_info])


### PR DESCRIPTION
Bumped to 1.1.0 because in theory this drops support for Python 2 which is notable enough.

Includes the following PRs:
- https://github.com/dimagi/couchdbkit/pull/81